### PR TITLE
Add initial navigation bar

### DIFF
--- a/Components/Background/Background.js
+++ b/Components/Background/Background.js
@@ -14,7 +14,7 @@ const animationFadeOut = () =>
 
 const Container = styled.stop`
   animation: ${animationFadeIn};
-  offset-distance: 0%;
+  offset-distance: 50%;
   stop-opacity: 1;
 `;
 
@@ -22,13 +22,20 @@ const Fill = styled.rect`
   width: 100vw;
   height: 100vh;
   position: relative;
-  opacity: .75;
+  opacity: 1;
 `;
 
 const Overlay = styled.stop`
   animation: ${animationFadeOut};
-  offset-distance: 100%;
-  stop-opacity: 1;
+  offset-distance: 50%;
+  stop-opacity: .75;
+`;
+
+const Svg = styled.svg`
+  left: 0;
+  position: absolute;
+  top: 0;
+  z-index: -1;
 `;
 
 const fadeIn = keyframes`
@@ -68,7 +75,7 @@ const fadeOut = keyframes`
 
 export const Background = () => {
   return (
-    <svg viewBox="0 0 100 100">
+    <Svg viewBox="0 0 100 100">
       <defs>
         <linearGradient id="fill" x1="0%" y1="0%" x2="0%" y2="100%">
           <Container />
@@ -76,7 +83,7 @@ export const Background = () => {
         </linearGradient>
       </defs>
       <Fill fill="url(#fill)"  />
-    </svg>
+    </Svg>
   );
 }
 

--- a/Components/NavigationBar/NavigationBar.js
+++ b/Components/NavigationBar/NavigationBar.js
@@ -1,0 +1,54 @@
+import React from 'react';
+import styled from 'styled-components';
+
+const NavigationContainer = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  height: 120px;
+  margin-top: 48px;
+  margin-left: 120px;
+  margin-right: 120px;
+`;
+
+const Name= styled.div`
+  font-family: 'Karla';
+  font-size: 44px;
+  line-height: 64px;
+`;
+
+const SectionsContainer = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+`;
+
+const Section = styled.div`
+  color: #1B1B3A;
+  font-family: 'Karla';
+  font-size: 32px;
+  line-height: 24px;
+  padding-right: 84px;
+  transition: color 1s steps(4, end);
+  &:hover {
+    color: white
+  }
+`;
+
+export const NavigationBar = () => {
+  return (
+    <NavigationContainer>
+      <Name>{"MARISSA BIESECKER"}</Name>
+
+      <SectionsContainer>
+        <Section>{"HOME"}</Section>
+
+        <Section>{"ABOUT"}</Section>
+
+        <Section>{"FACETS"}</Section>
+
+        <Section>{"CONNECT"}</Section>
+      </SectionsContainer>
+    </NavigationContainer>
+  )
+}

--- a/Components/NavigationBar/index.js
+++ b/Components/NavigationBar/index.js
@@ -1,0 +1,1 @@
+export * from './NavigationBar';

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,4 +1,5 @@
 import { Background } from '../Components/Background';
+import { NavigationBar } from '../Components/NavigationBar';
 import { ThemeProvider } from 'styled-components';
 import React from 'react';
 
@@ -23,6 +24,8 @@ const Index = () => (
   <ThemeProvider theme={theme}>
     <>
       <Background />
+
+      <NavigationBar />
     </>
   </ThemeProvider>
 );


### PR DESCRIPTION
Adds an initial structure for a navigation bar. 
Idea will be something like to click on the navigation and have an auto scroll down to that section.

<img width="50%" alt="Screen Shot 2020-02-16 at 7 45 43 PM" src="https://user-images.githubusercontent.com/28737090/74611566-f2903200-50f4-11ea-89bc-b56843643c49.png">

So for future enhancements:
- scroll on slick to sections (that will need to be added)
- on hover effect should be something more like a gemstone reflection
- want to add a background signature effect to the name
- improve flex layout for smaller screens (including background behavior)
