### PR TITLE
Update logo menu to scroll

### DIFF
--- a/Components/LogoMenu/LogoMenu.js
+++ b/Components/LogoMenu/LogoMenu.js
@@ -3,20 +3,27 @@ import styled from 'styled-components';
 import SvgLogo from '../../images/Logo.svg';
 
 const Container = styled.div`
-  background-color: transparent;
   background-repeat: no-repeat;
   background-position: center;
   align-self: center;
-  height: 72px;
-  width: 200px;
   margin-top: 24px;
   margin-left: 24px;
   margin-right: 24px;
+  position: ${props => props.position};
+  bottom:  ${props => props.position === 'fixed' ? '0px': null};
+  padding-top: 32px;
+  padding-left: 12px;
+  padding-right: 12px;
+  border-radius: 100%;
+
+  &:hover {
+    background-image: radial-gradient(rgb(46,49,56), rgb(46,49,56, .3), rgb(46,49,56, .01), rgb(46,49,56, .0001));
+  }
 `;
 
-export const LogoMenu = () => {
+export const LogoMenu = ({position}) => {
   return (
-    <Container>
+    <Container position={position}>
       <SvgLogo />
     </Container>
   )

--- a/Components/MainSection/MainSection.js
+++ b/Components/MainSection/MainSection.js
@@ -13,7 +13,7 @@ export const MainSection = () => {
     <Section column>
       <NavigationBar />
 
-        <LogoMenu />
+        <LogoMenu position={'fixed'} />
     </Section>
   );
 }

--- a/Components/NavigationBar/NavigationBar.js
+++ b/Components/NavigationBar/NavigationBar.js
@@ -24,7 +24,7 @@ const SectionsContainer = styled.div`
 `;
 
 const Section = styled.div`
-  color: #1B1B3A;
+  color: #2E3138;
   font-family: 'Karla';
   font-size: 32px;
   line-height: 24px;

--- a/Styles/styles.css
+++ b/Styles/styles.css
@@ -8,6 +8,7 @@
 }
 
 body {
+  background-color: #2E3138;
   font-family: 'Karla', helvetica neue, Helvetica, sans-serif;
   font-family: 'Vesper Libre', serif;
   font-size: 16px;


### PR DESCRIPTION
Updates menu SVG position to a bottom fixed position on scroll and added a hover background.

- will need to add the navigation menu to this SVG on hover or click after scrolling down to other sections (that also need to be added)
- tried a different way of passing styled component props. slightly different use cases, still need to figure out best practice

Also adjusted the colors of the links and body so that colors are consistent and the body has a less jarring color when scrolling the page as the background SVG is only a container within the body.